### PR TITLE
Adding Curb and getting latest kong state on current_consumers refs #8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'json'
 gem 'unicorn'
 gem 'ruby-kafka', '= 0.3.11'
 gem 'dotenv'
+gem 'curb', '~> 0.9.3', '>= 0.9.3'
 gem 'octocore', '~> 0.0.5', '>= 0.0.5'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     cequel (1.10.0)
       activemodel (~> 4.0)
       cassandra-driver (~> 2.0)
+    curb (0.9.3)
     descriptive_statistics (2.5.1)
     diff-lcs (1.2.5)
     dotenv (2.1.1)
@@ -123,6 +124,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  curb (~> 0.9.3, >= 0.9.3)
   dotenv
   json
   octocore (~> 0.0.5, >= 0.0.5)

--- a/bin/create_kong_config.rb
+++ b/bin/create_kong_config.rb
@@ -100,11 +100,10 @@ module Octo
       make_kong_request method, url, payload
     end
 
+    # Gets the current consumers listed in Kong.
     def current_consumers
-      unless @current_consumers
-        make_kong_request :get, '/consumers/' do |r|
-          @current_consumers = r
-        end
+      make_kong_request :get, '/consumers/' do |r|
+        @current_consumers = r
       end
       @current_consumers
     end


### PR DESCRIPTION
Sometimes the `create_kong_config` throws error in creating rate limiting plugin at kong. The reason identified is because `current_consumers` caches the list of consumers, and it can be disastrous in the initial setup stage when there are no consumers. So, when new consumers are added, the state reflected by `current_config` stays the same. This patch is supposed to fix this
